### PR TITLE
AO-LABS-001: Set security review label as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ It scans new or changed dependencies only (from your lock/manifest), pulls healt
     
 > **Non-blocking by default:** It is not a hard block just a speedbump so you can be alerted if something suspicious detected. Your CI pipeline won't fail, but dependency risks will be surfaced in the comment. You can comment `accept-risk` on the PR to suppress future notifications for the flagged packages until you do another commit to the manifest.
 
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `package_file` | Yes | — | Path to lock/manifest file (e.g., `poetry.lock`, `package-lock.json`, `go.mod`) |
+| `add_security_label` | No | `"true"` | Whether to add the `security review` label when issues are found |
+
 ## Quick start
 
 Minimal workflow for a repo that uses Poetry / npm / Yarn / Go:
 
-```
+```yaml
 name: Heisenberg Health Check
 on:
   pull_request:
@@ -37,7 +44,7 @@ on:
 permissions:
   contents: read
   pull-requests: write   # PR comment
-  issues: write          # create label
+  issues: write          # create label (only needed if add_security_label is true)
 
 jobs:
   deps-health:
@@ -57,4 +64,16 @@ jobs:
         uses: AppOmni-Labs/heisenberg-ssc-gha@v1
         with:
           package_file: ${{ steps.detect.outputs.lock_path }}
+```
+
+### Disable the security review label
+
+If you don't want the action to add the `security review` label to PRs with flagged dependencies, set `add_security_label` to `"false"`:
+
+```yaml
+      - name: Heisenberg Dependency Health Check
+        uses: AppOmni-Labs/heisenberg-ssc-gha@v1
+        with:
+          package_file: ${{ steps.detect.outputs.lock_path }}
+          add_security_label: "false"
 ```

--- a/README.md
+++ b/README.md
@@ -18,13 +18,6 @@ It scans new or changed dependencies only (from your lock/manifest), pulls healt
     
 > **Non-blocking by default:** It is not a hard block just a speedbump so you can be alerted if something suspicious detected. Your CI pipeline won't fail, but dependency risks will be surfaced in the comment. You can comment `accept-risk` on the PR to suppress future notifications for the flagged packages until you do another commit to the manifest.
 
-## Inputs
-
-| Input | Required | Default | Description |
-|-------|----------|---------|-------------|
-| `package_file` | Yes | — | Path to lock/manifest file (e.g., `poetry.lock`, `package-lock.json`, `go.mod`) |
-| `add_security_label` | No | `"true"` | Whether to add the `security review` label when issues are found |
-
 ## Quick start
 
 Minimal workflow for a repo that uses Poetry / npm / Yarn / Go:
@@ -68,7 +61,7 @@ jobs:
 
 ### Disable the security review label
 
-If you don't want the action to add the `security review` label to PRs with flagged dependencies, set `add_security_label` to `"false"`:
+If you don't want the action to add the `Security Review` label to PRs with flagged dependencies, set `add_security_label` to `"false"`:
 
 ```yaml
       - name: Heisenberg Dependency Health Check

--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
     description: "Path to lock/manifest (poetry.lock, uv.lock, package-lock.json, yarn.lock, requirements.txt, go.mod)"
     required: true
   add_security_label:
-    description: "Whether to add 'security review' label when issues are found"
+    description: "Specify if you want to add 'Security Review' label when issues are found"
     required: false
     default: "true"
 

--- a/action.yaml
+++ b/action.yaml
@@ -8,7 +8,11 @@ branding:
 inputs:
   package_file:
     description: "Path to lock/manifest (poetry.lock, uv.lock, package-lock.json, yarn.lock, requirements.txt, go.mod)"
-    required: true  
+    required: true
+  add_security_label:
+    description: "Whether to add 'security review' label when issues are found"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -280,7 +284,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}  
 
     - name: Add 'security review' label if needed
-      if: env.exit_code == '1' && steps.check_override.outputs.override_approved != 'true'
+      if: env.exit_code == '1' && steps.check_override.outputs.override_approved != 'true' && inputs.add_security_label == 'true'
       uses: actions-ecosystem/action-add-labels@v1
       with:
         github_token: ${{ github.token }}


### PR DESCRIPTION
This PR adds the ability to turn on or turn off `Security Review` label. 

```
add_security_label:
    description: "Specify if you want to add 'Security Review' label when issues are found"
    required: false
    default: "true"
```

In the calling action all you need to do is to set security label require to false under inputs:

`add_security_label: "false"`